### PR TITLE
Remove all uses of std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,6 @@ time = { version = "0.3", optional = true, default-features = false }
 chrono = { version = "0.4", optional = true, default-features = false }
 
 [features]
-default = ["std"]
-std = []
 serde-1 = ["serde", "serde_derive"]
 time-1 = ["time"]
 chrono-1 = ["chrono"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This crate converts MS DOS times to and from various formats, including integers, byte arrays, and
 types in external crates (see the features for more information).
 
+This crate is `no_std` compatible.
+
 An explanation of the date and time formats can be found
 [here](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-dosdatetimetofiletime),
 though the documentation for `DOSTime` and `DOSDate` also includes explantions for the format.
@@ -41,7 +43,6 @@ assert_eq!(time, DOSTime::try_from([0x1B, 0x6B]).unwrap());
 
 ## Features
 
-- `std` (default) - enables features that rely on the standard library
 - `serde-1` - enables (de)serialization with Serde
 - `time-1` - enables conversion to/from types in the `time` crate (`Date`, `Time`, and
 `PrimitiveDateTime`)

--- a/src/date.rs
+++ b/src/date.rs
@@ -309,9 +309,8 @@ impl Default for DOSDate {
     }
 }
 
-#[cfg(feature = "std")]
 impl Display for DOSDate {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:0>4}-{:0>2}-{:0>2}", self.year, self.month, self.day)
     }
 }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -272,9 +272,8 @@ impl Default for DOSDateTime {
     }
 }
 
-#[cfg(feature = "std")]
 impl Display for DOSDateTime {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{} {}", self.date, self.time)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![warn(missing_docs)]
 #![warn(clippy::missing_docs_in_private_items)]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 //! This crate converts MS DOS times to and from various formats, including integers, byte arrays, and
 //! types in external crates (see the features for more information).
@@ -43,7 +43,6 @@
 //! 
 //! # Features
 //! 
-//! - `std` (default) - enables features that rely on the standard library
 //! - `serde-1` - enables (de)serialization with Serde
 //! - `time-1` - enables conversion to/from types in the `time` crate (`Date`, `Time`, and
 //! `PrimitiveDateTime`)

--- a/src/time.rs
+++ b/src/time.rs
@@ -262,9 +262,8 @@ impl From<DOSTime> for [u8; 2] {
     }
 }
 
-#[cfg(feature = "std")]
 impl Display for DOSTime {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:0>2}:{:0>2}:{:0>2}", self.hour, self.minute, self.second)
     }
 }


### PR DESCRIPTION
This crate never actually needs `std` anywhere (`fmt::Display` is available in core), so remove the cargo feature and make this crate unconditionally `no_std`